### PR TITLE
added second docker login command to travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ python:
 before_install:
   - python -m pip install --upgrade pip
   - python -m pip install --upgrade py
+  - docker login -u "${DOCKERHUB_USERNAME}" -p "${DOCKERHUB_PASSWORD}";
 
 install:
   - pip install pipenv


### PR DESCRIPTION
# Motivation and Context
our travis builds are failing often due to dockerhub rate limiting failures, to solve this we need to log into an dockerhub enterprise account

# What has changed
- added a second docker login command line into .travis to use a enterprise dockerhub account

# How to test?
- trigger tests in travis and make sure it doesn't fail

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->

# Screenshots (if appropriate):
